### PR TITLE
et - Add Index Page for RecommendationRequest + tests

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,10 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -73,6 +77,21 @@ function App() {
             <>
               <Route exact path="/placeholder/edit/:id" element={<PlaceholderEditPage />} />
               <Route exact path="/placeholder/create" element={<PlaceholderCreatePage />} />
+            </>
+          )
+        }
+         {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/RecommendationRequest" element={<RecommendationRequestIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/RecommendationRequest/edit/:id" element={<RecommendationRequestEditPage />} />
+              <Route exact path="/RecommendationRequest/create" element={<RecommendationRequestCreatePage />} />
             </>
           )
         }

--- a/frontend/src/fixtures/recommendationRequestFixtures.js
+++ b/frontend/src/fixtures/recommendationRequestFixtures.js
@@ -1,4 +1,4 @@
-const recommendationRequestsFixtures = {
+const recommendationRequestFixtures = {
     oneRequest: {
         "id": 1,
         "requesterEmail": "cgaucho@ucsb.edu",
@@ -40,4 +40,4 @@ const recommendationRequestsFixtures = {
 };
 
 
-export { recommendationRequestsFixtures };
+export { recommendationRequestFixtures };

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -58,6 +58,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>
+                  <Nav.Link as={Link} to="/RecommendationRequest">Recommendation Request</Nav.Link>
                 </>
               )
             }

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestForm.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestForm.js
@@ -1,0 +1,175 @@
+import { Button, Form, Row, Col } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
+
+function RecommendationRequestForm({ initialContents, submitAction, buttonLabel = "Create" }) {
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialContents || {}, }
+    );
+    // Stryker restore all
+
+    const navigate = useNavigate();
+
+    // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+    // Note that even this complex regex may still need some tweaks
+
+    // Stryker disable all
+    const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+    const email_regex = /[a-z0-9]+@[a-z]+.[a-z]{2,3}/;
+    // Stryker restore all
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+
+            <Row>
+
+                {initialContents && (
+                    <Col>
+                        <Form.Group className="mb-3" >
+                            <Form.Label htmlFor="id">Id</Form.Label>
+                            <Form.Control
+                                data-testid="RecommendationRequestForm-id"
+                                id="id"
+                                type="text"
+                                {...register("id")}
+                                value={initialContents.id}
+                                disabled
+                            />
+                        </Form.Group>
+                    </Col>
+                )}
+
+                <Col>
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="requesterEmail">Requester Email</Form.Label>
+                        <Form.Control
+                            data-testid="RecommendationRequestForm-requesterEmail"
+                            id="requesterEmail"
+                            type="text"
+                            isInvalid={Boolean(errors.requesterEmail)}
+                            {...register("requesterEmail", { required: true, pattern: email_regex })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.requesterEmail && 'Requester Email is required.'}
+                            {errors.requesterEmail?.type === 'pattern' && 'Requester Email must be an email.'}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+            </Row>
+            <Row>
+                <Col>
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="professorEmail">Professor Email</Form.Label>
+                        <Form.Control
+                            data-testid="RecommendationRequestForm-professorEmail"
+                            id="professorEmail"
+                            type="text"
+                            isInvalid={Boolean(errors.professorEmail)}
+                            {...register("professorEmail", { required: true, pattern: email_regex })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.professorEmail && 'Professor Email is required.'}
+                            {errors.professorEmail?.type === 'pattern' && 'Professor Email must be an email.'}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+            </Row>
+            <Row>
+                <Col>
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="explanation">Explanation</Form.Label>
+                        <Form.Control
+                            data-testid="RecommendationRequestForm-explanation"
+                            id="explanation"
+                            type="text"
+                            isInvalid={Boolean(errors.explanation)}
+                            {...register("explanation", {
+                                required: "Explanation is required."
+                            })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.explanation?.message}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+            </Row>
+            <Row>
+                <Col>
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="dateRequested">Date Requested (iso format)</Form.Label>
+                        <Form.Control
+                            data-testid="RecommendationRequestForm-dateRequested"
+                            id="dateRequested"
+                            type="datetime-local"
+                            isInvalid={Boolean(errors.dateRequested)}
+                            {...register("dateRequested", { required: true, pattern: isodate_regex })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.dateRequested && 'Date Requested is required.'}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+                <Col>
+                    <Form.Group className="mb-3" >
+                        <Form.Label htmlFor="dateNeeded">Date Needed (iso format)</Form.Label>
+                        <Form.Control
+                            data-testid="RecommendationRequestForm-dateNeeded"
+                            id="dateNeeded"
+                            type="datetime-local"
+                            isInvalid={Boolean(errors.dateNeeded)}
+                            {...register("dateNeeded", { required: true, pattern: isodate_regex })}
+                        />
+                        <Form.Control.Feedback type="invalid">
+                            {errors.dateNeeded && 'Date Needed is required.'}
+                        </Form.Control.Feedback>
+                    </Form.Group>
+                </Col>
+
+                <Col>
+
+                    <Form.Group className="mb-3">
+                        <Form.Label htmlFor="done">Done Status</Form.Label>
+                        <Form.Control
+                            data-testid="RecommendationRequestForm-done"
+                            as="select"
+                            id="done"
+                            {...register("done")}
+                        >
+                            <option value={false}>False</option>
+                            <option value={true}>True</option>
+                        </Form.Control>
+                    </Form.Group>
+                </Col>
+            </Row>
+
+            <Row>
+                <Col>
+                    <Button
+                        type="submit"
+                        data-testid="RecommendationRequestForm-submit"
+                    >
+                        {buttonLabel}
+                    </Button>
+                    <Button
+                        variant="Secondary"
+                        onClick={() => navigate(-1)}
+                        data-testid="RecommendationRequestForm-cancel"
+                    >
+                        Cancel
+                    </Button>
+                </Col>
+            </Row>
+        </Form>
+
+    )
+}
+
+export default RecommendationRequestForm;

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -1,0 +1,71 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/RecommendationRequestUtils"
+import { useNavigate } from "react-router-dom";
+import { hasRole } from "main/utils/currentUser";
+
+export default function RecommendationRequestTable({ requests, currentUser }) {
+
+    const navigate = useNavigate();
+
+    const editCallback = (cell) => {
+        navigate(`/RecommendationRequest/edit/${cell.row.values.id}`)
+    }
+
+    // Stryker disable all : hard to test for query caching
+
+    const deleteMutation = useBackendMutation(
+        cellToAxiosParamsDelete,
+        { onSuccess: onDeleteSuccess },
+        ["/api/RecommendationRequest/all"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const deleteCallback = async (cell) => { deleteMutation.mutate(cell); }
+
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'Requester Email',
+            accessor: 'requesterEmail',
+        },
+        {
+            Header: 'Professor Email',
+            accessor: 'professorEmail',
+        },
+        {
+            Header: 'Explanation',
+            accessor: 'explanation',
+        },
+        {
+            Header: 'Date Requested',
+            accessor: 'dateRequested',
+        },
+        {
+            Header: 'Date Needed',
+            accessor: 'dateNeeded',
+        },
+        {
+            Header: 'Done Status',
+            accessor: 'done',
+        }
+    ];
+
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        columns.push(ButtonColumn("Edit", "primary", editCallback, "RecommendationRequestTable"));
+        columns.push(ButtonColumn("Delete", "danger", deleteCallback, "RecommendationRequestTable"));
+    } 
+
+    return <OurTable
+        data={requests}
+        columns={columns}
+        testid={"RecommendationRequestTable"}
+    />;
+};

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -54,7 +54,7 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
         },
         {
             Header: 'Done Status',
-            accessor: 'done',
+            accessor: d => d.done.toString(),
         }
     ];
 

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestCreatePage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestEditPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestIndexPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p><a href="/placeholder/create">Create</a></p>
+        <p><a href="/placeholder/edit/1">Edit</a></p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
@@ -1,14 +1,43 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RecommendationRequestTable from 'main/components/RecommendationRequest/RecommendationRequestTable';
+import { Button } from 'react-bootstrap';
+import { useCurrentUser , hasRole} from 'main/utils/currentUser';
 
 export default function RecommendationRequestIndexPage() {
 
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+        return (
+            <Button
+                variant="primary"
+                href="/RecommendationRequest/create"
+                style={{ float: "right" }}
+            >
+                Create Recommendation Request 
+            </Button>
+        )
+    } 
+  }
+  
+  const { data: requests, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/RecommendationRequest/all"],
+      { method: "GET", url: "/api/RecommendationRequest/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p><a href="/placeholder/create">Create</a></p>
-        <p><a href="/placeholder/edit/1">Edit</a></p>
+        {createButton()}
+        <h1>Recommendation Request</h1>
+        <RecommendationRequestTable requests={requests} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/utils/RecommendationRequestUtils.js
+++ b/frontend/src/main/utils/RecommendationRequestUtils.js
@@ -1,0 +1,17 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+    return {
+        url: "/api/RecommendationRequest",
+        method: "DELETE",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+

--- a/frontend/src/stories/components/RecommendationRequest/RecommendationRequestForm.stories.js
+++ b/frontend/src/stories/components/RecommendationRequest/RecommendationRequestForm.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm"
+import { recommendationRequestFixtures } from 'fixtures/recommendationRequestFixtures';
+
+export default {
+    title: 'components/RecommendationRequest/RecommendationRequestForm',
+    component: RecommendationRequestForm
+};
+
+
+const Template = (args) => {
+    return (
+        <RecommendationRequestForm {...args} />
+    )
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+    buttonLabel: "Create",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+    initialContents: recommendationRequestFixtures.oneDate,
+    buttonLabel: "Update",
+    submitAction: (data) => {
+        console.log("Submit was clicked with data: ", data); 
+        window.alert("Submit was clicked with data: " + JSON.stringify(data));
+   }
+};

--- a/frontend/src/stories/components/RecommendationRequest/RecommendationRequestTable.stories.js
+++ b/frontend/src/stories/components/RecommendationRequest/RecommendationRequestTable.stories.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+import { recommendationRequestFixtures } from 'fixtures/recommendationRequestFixtures';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
+import { rest } from "msw";
+
+export default {
+    title: 'components/RecommendationRequest/RecommendationRequestTable',
+    component: RecommendationRequestTable
+};
+
+const Template = (args) => {
+    return (
+        <RecommendationRequestTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    requests: []
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+    requests: recommendationRequestFixtures.threeRequests,
+    currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+    requests: recommendationRequestFixtures.threeRequests,
+    currentUser: currentUserFixtures.adminUser,
+}
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.delete('/api/RecommendationRequest', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+};
+

--- a/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestIndexPage.stories.js
+++ b/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestIndexPage.stories.js
@@ -1,0 +1,66 @@
+
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { rest } from "msw";
+
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+
+export default {
+    title: 'pages/RecommendationRequest/RecommendationRequestIndexPage',
+    component: RecommendationRequestIndexPage
+};
+
+const Template = () => <RecommendationRequestIndexPage storybook={true}/>;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/RecommendationRequest/all', (_req, res, ctx) => {
+            return res(ctx.json([]));
+        }),
+    ]
+}
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/RecommendationRequest/all', (_req, res, ctx) => {
+            return res(ctx.json(recommendationRequestFixtures.threeRequests));
+        }),
+    ],
+}
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.adminUser));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/RecommendationRequest/all', (_req, res, ctx) => {
+            return res(ctx.json(recommendationRequestFixtures.threeRequests));
+        }),
+        rest.delete('/api/RecommendationRequest', (req, res, ctx) => {
+            window.alert("DELETE: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.js
@@ -1,0 +1,143 @@
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import RecommendationRequestForm from "main/components/RecommendationRequest/RecommendationRequestForm";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe("RecommendationRequestForm tests", () => {
+
+    test("renders correctly", async () => {
+
+        render(
+            <Router  >
+                <RecommendationRequestForm />
+            </Router>
+        );
+        await screen.findByText(/Requester Email/);
+        await screen.findByText(/Professor Email/);
+        await screen.findByText(/Explanation/);
+        await screen.findByText(/Date Requested/);
+        await screen.findByText(/Date Needed/);
+        await screen.findByText(/Done Status/);
+        await screen.findByText(/Create/);
+    });
+
+
+    test("renders correctly when passing in a RecommendationRequest", async () => {
+
+        render(
+            <Router  >
+                <RecommendationRequestForm initialContents={recommendationRequestFixtures.oneRequest} />
+            </Router>
+        );
+        await screen.findByTestId(/RecommendationRequestForm-id/);
+        expect(screen.getByText(/Id/)).toBeInTheDocument();
+        expect(screen.getByTestId(/RecommendationRequestForm-id/)).toHaveValue("1");
+    });
+
+
+    test("Correct Error messsages on bad input", async () => {
+
+        render(
+            <Router  >
+                <RecommendationRequestForm />
+            </Router>
+        );
+        await screen.findByTestId("RecommendationRequestForm-requesterEmail");
+        const requesterEmailField = screen.getByTestId("RecommendationRequestForm-requesterEmail");
+        const professorEmailField = screen.getByTestId("RecommendationRequestForm-professorEmail");
+        const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
+
+        fireEvent.change(requesterEmailField, { target: { value: 'wrong-input' } });
+        fireEvent.change(professorEmailField, { target: { value: 'wrong-input' } });
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/Requester Email must be an email./);
+        await screen.findByText(/Professor Email must be an email./);
+    });
+
+    test("Correct Error messsages on missing input", async () => {
+
+        render(
+            <Router  >
+                <RecommendationRequestForm />
+            </Router>
+        );
+        await screen.findByTestId("RecommendationRequestForm-submit");
+        const doneFalseField = screen.getByTestId("RecommendationRequestForm-done");
+        const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
+
+        fireEvent.click(submitButton);
+
+        await screen.findByText(/Requester Email is required./);
+        expect(screen.getByText(/Professor Email is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Explanation is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Date Requested is required./)).toBeInTheDocument();
+        expect(screen.getByText(/Date Needed is required./)).toBeInTheDocument();
+        expect(doneFalseField.value).toBe("false");
+
+    });
+
+    test("No Error messsages on good input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        render(
+            <Router  >
+                <RecommendationRequestForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await screen.findByTestId("RecommendationRequestForm-requesterEmail");
+
+        const requesterEmailField = screen.getByTestId("RecommendationRequestForm-requesterEmail");
+        const professorEmailField = screen.getByTestId("RecommendationRequestForm-professorEmail");
+        const explanationField = screen.getByTestId("RecommendationRequestForm-explanation");
+        const dateRequestedFields = screen.getByTestId("RecommendationRequestForm-dateRequested");
+        const dateNeededFields = screen.getByTestId("RecommendationRequestForm-dateNeeded");
+        const doneTrueField = screen.getByTestId("RecommendationRequestForm-done");
+        const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
+
+        fireEvent.change(requesterEmailField, { target: { value: 'cgaucho@ucsb.edu' } });
+        fireEvent.change(professorEmailField, { target: { value: 'phtcon@ucsb.edu' } });
+        fireEvent.change(explanationField, { target: { value: 'BS/MS program' } });
+        fireEvent.change(dateRequestedFields, { target: { value: '2022-04-20T00:00:00' } });
+        fireEvent.change(dateNeededFields, { target: { value: '2022-05-01T00:00:00' } });
+        fireEvent.change(doneTrueField, { target: { value: true } });
+        
+        
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+        expect(screen.queryByText(/Requester Email must be an email./)).not.toBeInTheDocument();
+        expect(screen.queryByText(/Professor Email must be an email./)).not.toBeInTheDocument();
+        expect(doneTrueField.value).toBe("true");
+
+    });
+
+
+    test("that navigate(-1) is called when Cancel is clicked", async () => {
+
+        render(
+            <Router  >
+                <RecommendationRequestForm />
+            </Router>
+        );
+        await screen.findByTestId("RecommendationRequestForm-cancel");
+        const cancelButton = screen.getByTestId("RecommendationRequestForm-cancel");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+
+    });
+
+});

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -1,0 +1,121 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable"
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+describe("UserTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("Has the expected column headers and content for ordinary user", () => {
+
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestTable requests={recommendationRequestFixtures.threeRequests} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["id", "Requester Email", "Professor Email", "Explanation", "Date Requested", "Date Needed", "Done Status"];
+    const expectedFields = ["id", "requesterEmail", "professorEmail", "explanation", "dateRequested", "dateNeeded", "done"];
+    const testId = "RecommendationRequestTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    const editButton = screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).not.toBeInTheDocument();
+
+    const deleteButton = screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).not.toBeInTheDocument();
+
+  });
+
+  test("Has the expected colum headers and content for adminUser", () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestTable requests={recommendationRequestFixtures.threeRequests} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    const expectedHeaders = ["id", "Requester Email", "Professor Email", "Explanation", "Date Requested", "Date Needed", "Done Status"];
+    const expectedFields = ["id", "requesterEmail", "professorEmail", "explanation", "dateRequested", "dateNeeded", "done"];
+    const testId = "RecommendationRequestTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+
+    const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+
+  });
+
+  test("Edit button navigates to the edit page for admin user", async () => {
+
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestTable requests={recommendationRequestFixtures.threeRequests} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+
+    );
+
+    await waitFor(() => { expect(screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+
+    const editButton = screen.getByTestId(`RecommendationRequestTable-cell-row-0-col-Edit-button`);
+    expect(editButton).toBeInTheDocument();
+    
+    fireEvent.click(editButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/RecommendationRequest/edit/1'));
+
+  });
+
+});

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -116,6 +116,32 @@ describe("UserTable tests", () => {
 
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/RecommendationRequest/edit/1'));
 
+    });
+
+    test("Delete button calls delete callback", async () => {
+        // arrange
+        const currentUser = currentUserFixtures.adminUser;
+    
+        // act - render the component
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <RecommendationRequestTable requests={recommendationRequestFixtures.threeRequests} currentUser={currentUser} />
+            </MemoryRouter>
+          </QueryClientProvider>
+        );
+
+        const testId = "RecommendationRequestTable";
+    
+        // assert - check that the expected content is rendered
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-professorEmail`)).toHaveTextContent("phtcon@ucsb.edu");
+    
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+    
+        // act - click the delete button
+        fireEvent.click(deleteButton);
   });
 
 });

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -30,7 +30,7 @@ describe("UserTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Requester Email", "Professor Email", "Explanation", "Date Requested", "Date Needed", "Done Status"];
-    const expectedFields = ["id", "requesterEmail", "professorEmail", "explanation", "dateRequested", "dateNeeded", "done"];
+    const expectedFields = ["id", "requesterEmail", "professorEmail", "explanation", "dateRequested", "dateNeeded", "Done Status"];
     const testId = "RecommendationRequestTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -68,7 +68,7 @@ describe("UserTable tests", () => {
     );
 
     const expectedHeaders = ["id", "Requester Email", "Professor Email", "Explanation", "Date Requested", "Date Needed", "Done Status"];
-    const expectedFields = ["id", "requesterEmail", "professorEmail", "explanation", "dateRequested", "dateNeeded", "done"];
+    const expectedFields = ["id", "requesterEmail", "professorEmail", "explanation", "dateRequested", "dateNeeded", "Done Status"];
     const testId = "RecommendationRequestTable";
 
     expectedHeaders.forEach((headerText) => {
@@ -83,6 +83,7 @@ describe("UserTable tests", () => {
 
     expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Done Status`)).toHaveTextContent("false");
 
     const editButton = screen.getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("RecommendationRequestCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+       
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+    });
+
+});

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.js
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("RecommendationRequestEditPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+    });
+
+});

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("RecommendationRequestIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+    });
+
+});
+

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
@@ -1,17 +1,32 @@
-import { render, screen } from "@testing-library/react";
-import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
 
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("RecommendationRequestIndexPage tests", () => {
 
     const axiosMock = new AxiosMockAdapter(axios);
+
+    const testId = "RecommendationRequestTable";
 
     const setupUserOnly = () => {
         axiosMock.reset();
@@ -20,11 +35,18 @@ describe("RecommendationRequestIndexPage tests", () => {
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
     };
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
 
-        setupUserOnly();
+    test("Renders with Create Button for admin user", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/RecommendationRequest/all").reply(200, []);
 
         // act
         render(
@@ -36,10 +58,97 @@ describe("RecommendationRequestIndexPage tests", () => {
         );
 
         // assert
-        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
-        expect(screen.getByText("Create")).toBeInTheDocument();
-        expect(screen.getByText("Edit")).toBeInTheDocument();
+        await waitFor( ()=>{
+            expect(screen.getByText(/Create Recommendation Request/)).toBeInTheDocument();
+        });
+        const button = screen.getByText(/Create Recommendation Request/);
+        expect(button).toHaveAttribute("href", "/RecommendationRequest/create");
+        expect(button).toHaveAttribute("style", "float: right;");
+    });
+
+    test("renders three requests correctly for regular user", async () => {
+        
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/RecommendationRequest/all").reply(200, recommendationRequestFixtures.threeRequests);
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1"); });
+        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+        expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent("3");
+
+        // assert that the Create button is not present when user isn't an admin
+        expect(screen.queryByText(/Create Recommendation Request/)).not.toBeInTheDocument();
+
+    });
+
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        // arrange
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/RecommendationRequest/all").timeout();
+        const restoreConsole = mockConsole();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/RecommendationRequest/all");
+        restoreConsole();
+
+        expect(screen.queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
+
+    test("what happens when you click delete, admin", async () => {
+        // arrange
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/RecommendationRequest/all").reply(200, recommendationRequestFixtures.threeRequests);
+        axiosMock.onDelete("/api/RecommendationRequest").reply(200, "RecommendationRequest with id 1 was deleted");
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        await waitFor(() => { expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument(); });
+
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+
+        const deleteButton = screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+        expect(deleteButton).toBeInTheDocument();
+
+        // act
+        fireEvent.click(deleteButton);
+
+        // assert
+        await waitFor(() => { expect(mockToast).toBeCalledWith("RecommendationRequest with id 1 was deleted") });
+
     });
 
 });
-

--- a/frontend/src/tests/utils/RecommendationRequestUtils.test.js
+++ b/frontend/src/tests/utils/RecommendationRequestUtils.test.js
@@ -1,0 +1,53 @@
+import { onDeleteSuccess, cellToAxiosParamsDelete } from "main/utils/RecommendationRequestUtils";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("RecommendationRequestUtils", () => {
+
+    describe("onDeleteSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onDeleteSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsDelete", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 17 } } };
+
+            // act
+            const result = cellToAxiosParamsDelete(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/RecommendationRequest",
+                method: "DELETE",
+                params: { id: 17 }
+            });
+        });
+
+    });
+});


### PR DESCRIPTION
In this PR, I added an index page for RecommendationRequest that displays a table with all the data available.

![image](https://github.com/ucsb-cs156-s24/team03-s24-4pm-8/assets/97640991/7b2bf259-d846-48e0-b724-a8155d58a8bc)

Storybook link: https://ucsb-cs156-s24.github.io/team03-s24-4pm-8/prs/94/storybook/?path=/story/pages-recommendationrequest-recommendationrequestindexpage--empty

Closes #32